### PR TITLE
Change nib.get_data to nib.get_fdata then convert to np.int16

### DIFF
--- a/histogram/dask-array_histogram.py
+++ b/histogram/dask-array_histogram.py
@@ -35,7 +35,7 @@ def get_voxels(filename, start, args):
     with open(filename, "rb") as f_in:
         fh = nib.FileHolder(fileobj=BytesIO(f_in.read()))
         img = nib.Nifti1Image.from_file_map({"header": fh, "image": fh})
-    data = img.get_fdata()
+    data = img.get_fdata(caching="unchanged")
     data = nib.casting.float_to_int(data, np.int16)
 
     end_time = time() - start

--- a/histogram/dask-array_histogram.py
+++ b/histogram/dask-array_histogram.py
@@ -11,6 +11,7 @@ import dask
 import dask.array as da
 from dask.distributed import Client
 import nibabel as nib
+import numpy as np
 
 from utils import benchmark, crawl_dir
 
@@ -34,7 +35,8 @@ def get_voxels(filename, start, args):
     with open(filename, "rb") as f_in:
         fh = nib.FileHolder(fileobj=BytesIO(f_in.read()))
         img = nib.Nifti1Image.from_file_map({"header": fh, "image": fh})
-    data = img.get_data()
+    data = img.get_fdata()
+    data = nib.casting.float_to_int(data, np.int16)
 
     end_time = time() - start
 

--- a/utils.py
+++ b/utils.py
@@ -92,9 +92,8 @@ def read_img(filename, start, args):
     with open(filename, "rb") as f_in:
         fh = nib.FileHolder(fileobj=BytesIO(f_in.read()))
         img = nib.Nifti1Image.from_file_map({"header": fh, "image": fh})
-    data = img.get_fdata()
+    data = img.get_fdata(caching="unchanged")
     data = nib.casting.float_to_int(data, np.int16)
-
 
     end_time = time() - start
 

--- a/utils.py
+++ b/utils.py
@@ -92,7 +92,9 @@ def read_img(filename, start, args):
     with open(filename, "rb") as f_in:
         fh = nib.FileHolder(fileobj=BytesIO(f_in.read()))
         img = nib.Nifti1Image.from_file_map({"header": fh, "image": fh})
-    data = img.get_data()
+    data = img.get_fdata()
+    data = nib.casting.float_to_int(data, np.int16)
+
 
     end_time = time() - start
 


### PR DESCRIPTION
Modified the way the data is read  since `nibabel.Nifti1Image.get_data` is deprecated and replaced by `get_fdata`.